### PR TITLE
ethtool: add LinkModeUpdate and Client.UpdateLinkMode

### DIFF
--- a/client.go
+++ b/client.go
@@ -99,6 +99,14 @@ type LinkMode struct {
 	Duplex        Duplex
 }
 
+// LinkModeUpdate contains an update to the link mode information
+// for an Ethernet interface.
+type LinkModeUpdate struct {
+	SpeedMegabits *int
+	Ours, Peer    []AdvertisedLinkMode
+	Duplex        *Duplex
+}
+
 // A Duplex is the link duplex type for a LinkMode structure.
 type Duplex int
 
@@ -129,6 +137,13 @@ func (c *Client) LinkModes() ([]*LinkMode, error) {
 // returned.
 func (c *Client) LinkMode(ifi Interface) (*LinkMode, error) {
 	return c.c.LinkMode(ifi)
+}
+
+// UpdateLinkMode updates link mode information for the specified Interface.
+//
+// Specifically, the interface is brought to agreement with the non-nil fields of lmu.
+func (c *Client) UpdateLinkMode(ifi Interface, lmu *LinkModeUpdate) error {
+	return c.c.UpdateLinkMode(ifi, lmu)
 }
 
 // LinkState contains link state information for an Ethernet interface.


### PR DESCRIPTION
This proposes an interface for partial updates of link mode information. Tests coming up: wanted to make sure the overall design was acceptable first. The motivation behind disjoining LinkMode and LinkModeUpdate is that:

1. The sets of readable and writable fields are not the same, e.g. `ETHTOOL_A_LINKMODES_MASTER_SLAVE_STATE` is only readable and `ETHTOOL_A_LINKMODES_LANES` is only writable per [docs](https://www.kernel.org/doc/html/latest/networking/ethtool-netlink.html).
2. This allows for a natural (for golang) partial update interface via nullable fields.

One point on which I waver is whether slices should have encoding/json-type semantics (nil <> empty slice) as proposed here, or perhaps be pointers like everything else. Let me know what you think.