### PR TITLE
Add FEC() and SetFEC() methods to configure forward error correction

### DIFF
--- a/bitset_linux.go
+++ b/bitset_linux.go
@@ -76,3 +76,9 @@ func (bs *bitset) decode(b []byte) error {
 
 	return nil
 }
+
+// test is like the ethnl_bitmap32_test_bit() function in the Linux kernel: it
+// reports whether the bit with the specified index is set in the bitset.
+func (bs *bitset) test(idx int) bool {
+	return (*bs)[idx/32]&(1<<(idx%32)) != 0
+}

--- a/client.go
+++ b/client.go
@@ -1,6 +1,8 @@
 package ethtool
 
-import "fmt"
+import (
+	"fmt"
+)
 
 //go:generate stringer -type=Duplex,Port -output=string.go
 //go:generate go run mklinkmodes.go
@@ -151,6 +153,42 @@ func (c *Client) LinkStates() ([]*LinkState, error) {
 func (c *Client) LinkState(ifi Interface) (*LinkState, error) {
 	return c.c.LinkState(ifi)
 }
+
+// FEC fetches the forward error correction (FEC) setting for the specified
+// Interface.
+func (c *Client) FEC(ifi Interface) (*FEC, error) {
+	return c.c.FEC(ifi)
+}
+
+// SetFEC sets the forward error correction (FEC) parameters for the Interface
+// in fec.
+//
+// Setting FEC parameters requires elevated privileges and if the caller
+// does not have permission, an error compatible with errors.Is(err,
+// os.ErrPermission) will be returned.
+//
+// If the requested device does not exist or is not supported by the ethtool
+// interface, an error compatible with errors.Is(err, os.ErrNotExist) will be
+// returned.
+func (c *Client) SetFEC(fec FEC) error {
+	return c.c.SetFEC(fec)
+}
+
+// A FEC contains the forward error correction (FEC) parameters for an
+// interface.
+type FEC struct {
+	Interface Interface
+	Modes     FECModes
+	Active    FECMode
+	Auto      bool
+}
+
+// A FECMode is a FEC mode bit value (single element bitmask) specifying the
+// active mode of an interface.
+type FECMode int
+
+// A FECModes is a FEC mode bitmask of mode(s) supported by an interface.
+type FECModes FECMode
 
 // A WakeOnLAN contains the Wake-on-LAN parameters for an interface.
 type WakeOnLAN struct {

--- a/client_others.go
+++ b/client_others.go
@@ -26,4 +26,11 @@ func (c *client) LinkState(_ Interface) (*LinkState, error) { return nil, errUns
 func (c *client) WakeOnLANs() ([]*WakeOnLAN, error)         { return nil, errUnsupported }
 func (c *client) WakeOnLAN(_ Interface) (*WakeOnLAN, error) { return nil, errUnsupported }
 func (c *client) SetWakeOnLAN(_ WakeOnLAN) error            { return errUnsupported }
+func (c *client) FEC(_ Interface) (*FEC, error)             { return nil, errUnsupported }
+func (c *client) SetFEC(_ FEC) error                        { return errUnsupported }
 func (c *client) Close() error                              { return errUnsupported }
+
+func (f *FEC) Supported() FECModes { return 0 }
+
+func (f FECMode) String() string  { return "unsupported" }
+func (f FECModes) String() string { return "unsupported" }


### PR DESCRIPTION
Some network card and SFP module combinations (e.g. Mellanox ConnectX-4 with a
Flexoptix P.B1625G.10.AD) need to explicitly be configured to use RS forward
error correction, otherwise they won’t link.

I changed the get() function to only set the COMPACT_BITSETS flag for query
commands so that the resulting request byte sequence matches the ethtool(8) byte
sequence 1:1 (see TestFEC). Functionally, there is no change in behavior,
as can be verified by looking at the corresponding Linux kernel code :)