### PR TITLE
Update build

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -12,18 +12,21 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: ["1.19","1.20"]
+        go-version:
+          - "1.21.x"
+          - "1.22.x"
+          - "1.23.x"
     runs-on: ubuntu-latest
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,19 +13,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.19","1.20"]
+        go-version:
+          - "1.21.x"
+          - "1.22.x"
+          - "1.23.x"
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0
         with:
           go-version: ${{ matrix.go-version }}
         id: go
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Run tests
         run: go test -race ./...

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mdlayher/ethtool
 
-go 1.19
+go 1.21.0
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
* Update Go minimum to 1.21 to support new features.
* Update test matrix to latest 3 releases.
* Bump GitHub actions.
* Pin GitHub actions to commit hashes for supply chain security.
* Enable dependabot for GitHub actions.