### PR TITLE
Update Go

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,9 +13,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.21.x"
-          - "1.22.x"
           - "1.23.x"
+          - "1.24.x"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.21.x"
-          - "1.22.x"
           - "1.23.x"
+          - "1.24.x"
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,13 @@
+---
+linters:
+  enable:
+    - misspell
+    - revive
+
+linters-settings:
+  revive:
+    rules:
+      # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#var-naming
+      # Disable due to use of ALL_CAPS consts.
+      - name: var-naming
+        disabled: true

--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,13 @@
 module github.com/mdlayher/ethtool
 
-go 1.21.0
+go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.7.0
 	github.com/josharian/native v1.1.0
 	github.com/mdlayher/genetlink v1.3.2
 	github.com/mdlayher/netlink v1.7.2
-	golang.org/x/sys v0.22.0
+	golang.org/x/sys v0.31.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -12,5 +12,5 @@ golang.org/x/net v0.9.0 h1:aWJ/m6xSmxWBx+V0XRHTlrYrPG56jKsLdTFmsSsCzOM=
 golang.org/x/net v0.9.0/go.mod h1:d48xBJpPfHeWQsugry2m+kC02ZBRGRgulfHnEXEuWns=
 golang.org/x/sync v0.1.0 h1:wsuoTGHzEhffawBOhz5CYhcrV4IdKZbEyZjBMuTp12o=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sys v0.22.0 h1:RI27ohtqKCnwULzJLqkv897zojh5/DwS/ENaMzUOaWI=
-golang.org/x/sys v0.22.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
+golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=


### PR DESCRIPTION
* Update Go minimum version to 1.23.
* Update CI test matrix
* Bump `golang.org/x/sys`.
* Add additional golangci-lint linters.