### PR TITLE
Use x/sys/cpu.IsBigEndian to determine endianness

### DIFF
--- a/client_linux.go
+++ b/client_linux.go
@@ -4,16 +4,15 @@
 package ethtool
 
 import (
-	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
 	"slices"
 	"strings"
 
-	"github.com/josharian/native"
 	"github.com/mdlayher/genetlink"
 	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/cpu"
 	"golang.org/x/sys/unix"
 )
 
@@ -186,7 +185,7 @@ func (lmu *LinkModeUpdate) encode(ae *netlink.AttributeEncoder) {
 			nae.Uint32(unix.ETHTOOL_A_BITSET_SIZE, uint32(bitlen))
 			b := make([]byte, ((bitlen+31)/32)*4)
 			b = lmu.Advertise.FillBytes(b)
-			if binary.ByteOrder(native.Endian) == binary.LittleEndian {
+			if !cpu.IsBigEndian {
 				// FillBytes is big endian, reverse bytes for host order
 				slices.Reverse(b)
 			}

--- a/client_linux_test.go
+++ b/client_linux_test.go
@@ -4,16 +4,15 @@
 package ethtool
 
 import (
-	"encoding/binary"
 	"os"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/josharian/native"
 	"github.com/mdlayher/genetlink"
 	"github.com/mdlayher/genetlink/genltest"
 	"github.com/mdlayher/netlink"
+	"golang.org/x/sys/cpu"
 	"golang.org/x/sys/unix"
 )
 
@@ -1029,7 +1028,7 @@ func TestSetPrivateFlags(t *testing.T) {
 func skipBigEndian(t *testing.T) {
 	t.Helper()
 
-	if binary.ByteOrder(native.Endian) == binary.BigEndian {
+	if cpu.IsBigEndian {
 		t.Skip("skipping, this test requires a little endian machine")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,13 @@ go 1.23.0
 
 require (
 	github.com/google/go-cmp v0.7.0
-	github.com/josharian/native v1.1.0
 	github.com/mdlayher/genetlink v1.3.2
 	github.com/mdlayher/netlink v1.7.2
 	golang.org/x/sys v0.34.0
 )
 
 require (
+	github.com/josharian/native v1.1.0 // indirect
 	github.com/mdlayher/socket v0.4.1 // indirect
 	golang.org/x/net v0.9.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect


### PR DESCRIPTION
josharian/native is literally just a wrapper around x/sys/cpu.IsBigEndian nowadays, making its import unnecessary.