### PR TITLE
Update Go versions

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       matrix:
         go-version:
-          - "1.23.x"
           - "1.24.x"
+          - "1.25.x"
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,8 +14,8 @@ jobs:
       fail-fast: false
       matrix:
         go-version:
-          - "1.23.x"
           - "1.24.x"
+          - "1.25.x"
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mdlayher/ethtool
 
-go 1.23.0
+go 1.24.0
 
 require (
 	github.com/google/go-cmp v0.7.0


### PR DESCRIPTION
* Update CI tests for latest versions.
* Update supported versions to 1.24.0.